### PR TITLE
Introduction of 'Sender' and 'Destination' for Sending and Receiving

### DIFF
--- a/default_handler.go
+++ b/default_handler.go
@@ -120,22 +120,20 @@ type exportedMethod struct {
 func (m exportedMethod) Call(sender Sender, args ...interface{}) ([]interface{}, error) {
 	t := m.Type()
 
-	argsLength := len(args)
-	startIdxForArguments := 0
 	hasSenderParam := false
-	if m.Type().In(0) == reflect.TypeOf(sender) {
-		argsLength++
-		startIdxForArguments++
+	if m.NumArguments() > 0 && m.Type().In(0) == reflect.TypeOf(sender) {
 		hasSenderParam = true
 	}
 
-	params := make([]reflect.Value, argsLength)
+	params := make([]reflect.Value, m.NumArguments())
 
+	startIdxForArgumentsCopy := 0
 	if hasSenderParam {
-		params[0] = reflect.ValueOf(sender).Elem()
+		params[0] = reflect.ValueOf(sender)
+		startIdxForArgumentsCopy = 1
 	}
 
-	for i := startIdxForArguments; i < len(args); i++ {
+	for i := startIdxForArgumentsCopy; i < m.NumArguments(); i++ {
 		reflect.TypeOf(&ErrMsgInvalidArg)
 		params[i] = reflect.ValueOf(args[i]).Elem()
 	}

--- a/default_handler.go
+++ b/default_handler.go
@@ -117,11 +117,26 @@ type exportedMethod struct {
 	reflect.Value
 }
 
-func (m exportedMethod) Call(args ...interface{}) ([]interface{}, error) {
+func (m exportedMethod) Call(sender Sender, args ...interface{}) ([]interface{}, error) {
 	t := m.Type()
 
-	params := make([]reflect.Value, len(args))
-	for i := 0; i < len(args); i++ {
+	argsLength := len(args)
+	startIdxForArguments := 0
+	hasSenderParam := false
+	if m.Type().In(0) == reflect.TypeOf(sender) {
+		argsLength++
+		startIdxForArguments++
+		hasSenderParam = true
+	}
+
+	params := make([]reflect.Value, argsLength)
+
+	if hasSenderParam {
+		params[0] = reflect.ValueOf(sender).Elem()
+	}
+
+	for i := startIdxForArguments; i < len(args); i++ {
+		reflect.TypeOf(&ErrMsgInvalidArg)
 		params[i] = reflect.ValueOf(args[i]).Elem()
 	}
 

--- a/export.go
+++ b/export.go
@@ -221,7 +221,7 @@ func (conn *Conn) handleCall(msg *Message) {
 	}
 }
 
-func (conn *Conn) EmitwithDestination(path ObjectPath, name string, dest Destination, values ...interface{}) error {
+func (conn *Conn) EmitWithDestination(path ObjectPath, name string, dest Destination, values ...interface{}) error {
 	i := strings.LastIndex(name, ".")
 	if i == -1 {
 		return errors.New("dbus: invalid method name")
@@ -233,7 +233,7 @@ func (conn *Conn) EmitwithDestination(path ObjectPath, name string, dest Destina
 	headers[FieldInterface] = MakeVariant(iface)
 	headers[FieldMember] = MakeVariant(member)
 	headers[FieldPath] = MakeVariant(path)
-	headers[FieldDestination] = MakeVariant(dest)
+	headers[FieldDestination] = MakeVariant(string(dest))
 
 	return conn.emitWithHeaders(headers, values...)
 }

--- a/export.go
+++ b/export.go
@@ -190,7 +190,7 @@ func (conn *Conn) handleCall(msg *Message) {
 		return
 	}
 
-	ret, err := m.Call(args...)
+	ret, err := m.Call(Sender(sender), args...)
 	if err != nil {
 		conn.sendError(err, sender, serial)
 		return

--- a/server_interfaces.go
+++ b/server_interfaces.go
@@ -38,7 +38,7 @@ type Interface interface {
 // A Method represents the exposed methods on D-Bus.
 type Method interface {
 	// Call requires that all arguments are decoded before being passed to it.
-	Call(args ...interface{}) ([]interface{}, error)
+	Call(sender Sender, args ...interface{}) ([]interface{}, error)
 	NumArguments() int
 	NumReturns() int
 	// ArgumentValue returns a representative value for the argument at position

--- a/server_interfaces_test.go
+++ b/server_interfaces_test.go
@@ -109,7 +109,7 @@ func (t *tester) LookupMethod(name string) (Method, bool) {
 }
 
 // Method
-func (t *tester) Call(args ...interface{}) ([]interface{}, error) {
+func (t *tester) Call(sender Sender, args ...interface{}) ([]interface{}, error) {
 	return args, nil
 }
 
@@ -131,7 +131,7 @@ func (t *tester) ReturnValue(position int) interface{} {
 
 type terrfn func(in string) error
 
-func (t terrfn) Call(args ...interface{}) ([]interface{}, error) {
+func (t terrfn) Call(sender Sender, args ...interface{}) ([]interface{}, error) {
 	return nil, t(*args[0].(*string))
 }
 
@@ -194,7 +194,7 @@ func (t *tester) RetireSerial(serial uint32) {}
 
 type intro_fn func() string
 
-func (intro intro_fn) Call(args ...interface{}) ([]interface{}, error) {
+func (intro intro_fn) Call(sender Sender, args ...interface{}) ([]interface{}, error) {
 	return []interface{}{intro()}, nil
 }
 


### PR DESCRIPTION
Hi,

we need to receive the DBus Sender of a message and we also want to pass the Destination header along with a message. Therefor we enhanced the dbus.Method interface to include another param of type "dbus.Sender" which will automatically set if the client impl has such a param. On the other hand we introduced a new type "dbus.Destination" which can be passed to Emit calls...

Kristian